### PR TITLE
Allow passing of file name from command line. Convert string to byte…

### DIFF
--- a/ts-parser.py
+++ b/ts-parser.py
@@ -1,7 +1,9 @@
-with open("3d1106a4-5c2a-4909-8d3a-1088b1ecc7db_ts_avc_hd_1571294026137.ts", "rb") as f:
+import sys
+
+with open(sys.argv[1], "rb") as f:
     data = f.read(188)  # just read the first 188 bytes
-    first_byte = data[0]
-    if first_byte == 0x47:
-        print("Found sync byte")
-    else:
+    first_byte = ord(data[0])
+    if first_byte != 0x47:
         print("Could not find sync byte. Not a valid transport stream file")
+    else:
+        print("Found sync byte")


### PR DESCRIPTION
* Allow the ability to pass in file name from command line.
* Convert the string character to integer whit `ord()` before comparing to literal
* Switch order of if and else, so it easier to add more logic as we go.