### PR TITLE
Update parser.ts

### DIFF
--- a/ts-parser.py
+++ b/ts-parser.py
@@ -2,7 +2,7 @@ import sys
 
 with open(sys.argv[1], "rb") as f:
     data = f.read(188)  # just read the first 188 bytes
-    first_byte = ord(data[0])
+    first_byte = data[0]
     if first_byte != 0x47:
         print("Could not find sync byte. Not a valid transport stream file")
     else:


### PR DESCRIPTION
The ord() introduces the following error: 
TypeError: ord() expected string of length 1, but int found

So this change is to remove ord()